### PR TITLE
js/rm_load.js: add additional data search path

### DIFF
--- a/js/rm_load.js
+++ b/js/rm_load.js
@@ -152,7 +152,7 @@ function get_context(file_path) {
 	};
 
 	Object.entries(context_files).forEach(([key, filepath]) => {
-		process.stdout.write('Loading... ' + filepath);
+		console.debug('Loading... ' + filepath);
 
 		if (!fs.existsSync(filepath)) {
 			console.warn('Missing context file ${filepath}, skipping.');


### PR DESCRIPTION
RPG Maker MV stores 'data' under 'www/data' not as a peer to the 'saves' directory, so look in both locations.  This also adds a bit of additional console output that was helpful in debugging and may be helpful if someone is loading up their saves and some items seem to be missing.