### PR TITLE
 Automatic Builds

### DIFF
--- a/.github/workflows/autobuild-and-publish-artifacts.yml
+++ b/.github/workflows/autobuild-and-publish-artifacts.yml
@@ -1,0 +1,121 @@
+name: Automatic Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release-linux-x64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - run: npm ci
+      - run: npx electron-packager . RPGMaker-Save-Editor --platform=linux --arch=x64 --out=dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-linux-x64-${{ github.ref_name }}-${{ github.sha }}
+          path: dist
+
+  release-windows-x64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - run: npm ci
+      - run: npx electron-packager . RPGMaker-Save-Editor --platform=win32 --arch=x64 --out=dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-win32-x64-${{ github.ref_name }}-${{ github.sha }}
+          path: dist
+
+  release-macos-x64-and-arm64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - run: npm ci
+      - run: npx electron-packager . RPGMaker-Save-Editor --platform=darwin --arch=x64 --out=dist-x64
+      - run: npx electron-packager . RPGMaker-Save-Editor --platform=darwin --arch=arm64 --out=dist-arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-darwin-x64-${{ github.ref_name }}-${{ github.sha }}
+          path: dist-x64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-darwin-arm64-${{ github.ref_name }}-${{ github.sha }}
+          path: dist-arm64
+
+  collect:
+    name: Publish artifacts to Release
+    runs-on: ubuntu-latest
+    environment: release
+    needs: [release-linux-x64, release-windows-x64, release-macos-x64-and-arm64]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4   # <-- Add this line
+  
+      - uses: actions/download-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-linux-x64-${{ github.ref_name }}-${{ github.sha }}
+          path: collected/linux
+      - uses: actions/download-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-win32-x64-${{ github.ref_name }}-${{ github.sha }}
+          path: collected/windows
+      - uses: actions/download-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-darwin-x64-${{ github.ref_name }}-${{ github.sha }}
+          path: collected/macos-x64
+      - uses: actions/download-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-darwin-arm64-${{ github.ref_name }}-${{ github.sha }}
+          path: collected/macos-arm64
+  
+      - name: Create GitHub Release
+        run: gh release create v${{ github.run_number }} --title "Release v${{ github.run_number }}" --notes "Automated build release"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Zip Linux build
+        run: zip -r RPGMaker-Save-Editor-linux-x64.zip collected/linux/
+
+      - name: Zip Windows build
+        run: zip -r RPGMaker-Save-Editor-windows-x64.zip collected/windows/
+
+      - name: Zip macOS x64 build
+        run: zip -r RPGMaker-Save-Editor-macos-x64.zip collected/macos-x64/
+
+      - name: Zip macOS arm64 build
+        run: zip -r RPGMaker-Save-Editor-macos-arm64.zip collected/macos-arm64/
+        
+      - name: Upload Linux asset
+        run: gh release upload v${{ github.run_number }} RPGMaker-Save-Editor-linux-x64.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Windows asset
+        run: gh release upload v${{ github.run_number }} RPGMaker-Save-Editor-windows-x64.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload macOS x64 asset
+        run: gh release upload v${{ github.run_number }} RPGMaker-Save-Editor-macos-x64.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload macOS arm64 asset
+        run: gh release upload v${{ github.run_number }} RPGMaker-Save-Editor-macos-arm64.zip --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+

--- a/.github/workflows/autobuild-and-publish-artifacts.yml
+++ b/.github/workflows/autobuild-and-publish-artifacts.yml
@@ -1,4 +1,4 @@
-name: Automatic Build
+name: Automatic Build and Publish artifacts to Release 
 
 on:
   workflow_dispatch:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, master ]
 
 jobs:
-  build-linux-x64:
+  release-linux-x64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
           name: RPGMaker-Save-Editor-linux-x64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{github.sha}}
           path: dist
 
-  build-windows-x64:
+  release-windows-x64:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
           name: RPGMaker-Save-Editor-win32-x64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{github.sha}}
           path: dist
 
-  build-macos:
+  release-macos:
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,0 +1,92 @@
+name: Automatic Build
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build-linux-x64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Build Electron app (Linux)
+        run: |
+          npm i -D electron-builder
+          npx electron-packager . RPGMaker-Save-Editor --platform=linux --arch=x64 --out=dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-linux-x64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{github.sha}}
+          path: dist
+
+  build-windows-x64:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Build Electron app (Windows)
+        run: |
+          npm i -D electron-builder
+          npx electron-packager . RPGMaker-Save-Editor --platform=win32 --arch=x64 --out=dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-win32-x64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{github.sha}}
+          path: dist
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm i
+  
+      - name: Build Electron app (macOS x64)
+        run: |
+          npm i -D electron-builder
+          npx electron-packager . RPGMaker-Save-Editor --platform=darwin --arch=x64 --out=dist-x64
+  
+      - name: Build Electron app (macOS arm64)
+        run: |
+          npx electron-packager . RPGMaker-Save-Editor --platform=darwin --arch=arm64 --out=dist-arm64
+  
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-darwin-x64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{github.sha}}
+          path: dist-x64
+  
+      - uses: actions/upload-artifact@v4
+        with:
+          name: RPGMaker-Save-Editor-darwin-arm64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{github.sha}}
+          path: dist-arm64

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -57,7 +57,7 @@ jobs:
           name: RPGMaker-Save-Editor-win32-x64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{github.sha}}
           path: dist
 
-  release-macos:
+  release-macos-x64-and-arm64:
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,10 +1,7 @@
 name: Automatic Build
 
 on:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+  workflow_dispatch:
 
 jobs:
   release-linux-x64:
@@ -24,7 +21,6 @@ jobs:
 
       - name: Build Electron app (Linux)
         run: |
-          npm i -D electron-builder
           npx electron-packager . RPGMaker-Save-Editor --platform=linux --arch=x64 --out=dist
 
       - uses: actions/upload-artifact@v4
@@ -49,7 +45,6 @@ jobs:
 
       - name: Build Electron app (Windows)
         run: |
-          npm i -D electron-builder
           npx electron-packager . RPGMaker-Save-Editor --platform=win32 --arch=x64 --out=dist
 
       - uses: actions/upload-artifact@v4
@@ -74,7 +69,6 @@ jobs:
   
       - name: Build Electron app (macOS x64)
         run: |
-          npm i -D electron-builder
           npx electron-packager . RPGMaker-Save-Editor --platform=darwin --arch=x64 --out=dist-x64
   
       - name: Build Electron app (macOS arm64)


### PR DESCRIPTION
Enable GitHub Actions autobuilds to generate release artifacts for Windows, Linux and macOS automatically.

They appear as workflow runs in the Actions tab, with downloadable builds attached.
